### PR TITLE
Decoupled deployment of Kubernetes service from individual MapReduce job

### DIFF
--- a/mihir_run/src/knn/jobs/__init__.py
+++ b/mihir_run/src/knn/jobs/__init__.py
@@ -1,1 +1,1 @@
-from .jobs import MapReduceJob
+from .jobs import MapReduceJob, MapperSpec


### PR DESCRIPTION
Allows repeated jobs of the same type to run much faster because deployment only happens once as opposed to on every job